### PR TITLE
Add validate-podspec command

### DIFF
--- a/src/danger/orb.yml
+++ b/src/danger/orb.yml
@@ -3,6 +3,9 @@ version: 2.1
 description: |
   Simplify running danger in a Github repo
 
+orbs:
+  ruby: sue445/ruby-orbs@1.4.0
+
 jobs:
   danger-ruby:
     description: |
@@ -13,17 +16,7 @@ jobs:
       - image: circleci/ruby:2.3
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - danger-gems-v1-{{ checksum "Gemfile.lock" }}
-            - danger-gems-v1-
-      - run:
-          name: Bundle install
-          command: bundle install --path=vendor/bundle
-      - save_cache:
-          key: danger-gems-v1-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/
+      - ruby/bundle-install
       - run:
           name: Danger
           command: |

--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -3,6 +3,32 @@ version: 2.1
 description: |
   Simplify common tasks for building and testing iOS projects
 
+orbs:
+  ruby: sue445/ruby-orbs@1.4.0
+
+executors:
+  default:
+    macos:
+      xcode: "10.1.0"
+
+jobs:
+  validate-podspec:
+    description: |
+      Run 'pod spec lint' on a provided .podspec file.
+    parameters:
+      podspec-path:
+        type: string
+    executor: default
+    steps:
+      - checkout
+      - ruby/bundle-install
+      - run:
+          name: Fetch CocoaPods Specs
+          command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - run:
+          name: Validate podspec
+          command: bundle exec pod lib lint "<< parameters.podspec-path >>"
+
 commands:
   cached-pod-install:
     description: |


### PR DESCRIPTION
Adds new `validate-podspec` command and uses an existing Orb to manage bundle install + caching.