### PR TITLE
Publish when the repository is tagged instead of every push to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,20 +30,24 @@ workflows:
           orb-ref: "wordpress-mobile/danger@dev:${CIRCLE_BRANCH}"
           requires: ["Validate Orbs"]
 
-      - orb-tools/increment:
+      - orb-tools/publish:
           name: "iOS: Publish"
           orb-path: src/ios/orb.yml
-          orb-ref: "wordpress-mobile/ios"
+          orb-ref: "wordpress-mobile/ios@${CIRCLE_TAG}"
           requires: ["Validate Orbs"]
           filters:
+            tags:
+              only: /.*/
             branches:
-              only: master
+              ignore: /.*/
 
-      - orb-tools/increment:
+      - orb-tools/publish:
           name: "Danger: Publish"
           orb-path: src/danger/orb.yml
-          orb-ref: "wordpress-mobile/danger"
+          orb-ref: "wordpress-mobile/danger@${CIRCLE_TAG}"
           requires: ["Validate Orbs"]
           filters:
+            tags:
+              only: /.*/
             branches:
-              only: master
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ This command will validate all the Orbs in `src/`:
 
 ## Publishing
 
-New Orb versions will be published to CircleCI on every merge to master. See `.circleci/config.yml` for deatils.
+Maintainers can publish a new version of the Orbs by making a new release on Github [here](https://github.com/wordpress-mobile/circleci-orbs/releases/new). This will cause this release to be published to the CircleCI Orb registry. See `.circleci/config.yml` for details.


### PR DESCRIPTION
Currently, the Orbs are published to the CircleCI Orb registry on every push to master, automatically incrementing the version. This works well but is a bit restrictive:

- The patch version is always incremented. This breaks semantic versioning since there may have been breaking changes.
- There is no record of releases in the repo.
- A new version is always published, even if the only change was a README edit.

This changes the config so that new versions are published when the repo is tagged. Now we can release a new version by simply creating a new Github release.