### PR TITLE
Add Orb for common Android tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,12 @@ workflows:
           orb-path: src/ios/orb.yml
           orb-ref: "wordpress-mobile/ios@dev:${CIRCLE_BRANCH}"
           requires: ["Validate Orbs"]
+      
+      - orb-tools/publish:
+          name: "Android: Publish Dev"
+          orb-path: src/android/orb.yml
+          orb-ref: "wordpress-mobile/android@dev:${CIRCLE_BRANCH}"
+          requires: ["Validate Orbs"]
 
       - orb-tools/publish:
           name: "Danger: Publish Dev"
@@ -34,6 +40,17 @@ workflows:
           name: "iOS: Publish"
           orb-path: src/ios/orb.yml
           orb-ref: "wordpress-mobile/ios@${CIRCLE_TAG}"
+          requires: ["Validate Orbs"]
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+
+      - orb-tools/publish:
+          name: "Android: Publish"
+          orb-path: src/android/orb.yml
+          orb-ref: "wordpress-mobile/android@${CIRCLE_TAG}"
           requires: ["Validate Orbs"]
           filters:
             tags:

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -1,0 +1,50 @@
+version: 2.1
+
+description: |
+  Simplify common tasks for building and testing Android projects
+
+commands:
+  generate-gradle-checksums:
+    steps:
+      - run:
+          name: Generate Gradle checksums
+          command: |
+            # This finds all *.gradle files (apart from the root build.gradle) and generates checksums for caching
+            find . -name "*.gradle" -type f -mindepth 2 | sort | xargs shasum > gradle-checksums.txt
+            cat gradle-checksums.txt
+  restore-gradle-cache:
+    description: Restore the cache of ~/.gradle based on the local build files.
+    parameters:
+      cache-prefix:
+        type: string
+        default: gradle-cache
+    steps:
+      - generate-gradle-checksums
+      - restore_cache:
+          keys:
+            - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "gradle-checksums.txt" }}
+            - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-
+            - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-
+  save-gradle-cache:
+    description: Cache the contents of ~/.gradle based on the local build files.
+    parameters:
+      cache-prefix:
+        type: string
+        default: gradle-cache
+    steps:
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "gradle-checksums.txt" }}
+  save-test-results:
+    steps:
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit


### PR DESCRIPTION
This adds a new Orb for dealing with some common Android tasks. It currently handles Gradle caching and storing test results.

This will help us to easily add CircleCI to our other Android projects.

Here is an Android build that uses the the orb from this branch: https://circleci.com/workflow-run/9199b0eb-717e-4333-9610-dd0dbd00425f