### PR TITLE
iOS: Disable indexing while building

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -96,7 +96,7 @@ jobs:
               fi
             }
 
-            XCODEBUILD_ARGS=""
+            XCODEBUILD_ARGS="COMPILER_INDEX_STORE_ENABLE=NO"
             XCODEBUILD_ARGS="${XCODEBUILD_ARGS} $(optional_argument "-workspace" "<< parameters.workspace >>")"
             XCODEBUILD_ARGS="${XCODEBUILD_ARGS} $(optional_argument "-project" "<< parameters.project >>")"
             XCODEBUILD_ARGS="${XCODEBUILD_ARGS} $(optional_argument "-scheme" "<< parameters.scheme >>")"


### PR DESCRIPTION
As suggested by @jklausa, Xcode's "index while building"  can be disabled for CI builds since it gives no benefit there.

This gives a minor, but welcome improvement to build times (around 30s for WPiOS): https://circleci.com/gh/wordpress-mobile/WordPress-iOS/4498