### PR TITLE
Android: Add default executor with sensible GRADLE_OPTS defaults

### DIFF
--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -3,6 +3,21 @@ version: 2.1
 description: |
   Simplify common tasks for building and testing Android projects
 
+executors:
+  default:
+    description: An executor with sensible defaults for Android Gradle tasks (set with GRADLE_OPTS).
+    parameters:
+      api-version:
+        description: The Android API version to use.
+        type: string
+        default: "27"
+    docker:
+      - image: circleci/android:api-<<parameters.api-version>>
+        environment:
+          # kotlin.incremental=false and kotlin.compiler.execution.strategy=in-process are required due to an issue with the Kotlin compiler in
+          # memory constrained environments: https://youtrack.jetbrains.com/issue/KT-15562
+          GRADLE_OPTS: -Xmx1536m -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.caching=true -Dorg.gradle.configureondemand=true -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false
+
 commands:
   generate-gradle-checksums:
     steps:


### PR DESCRIPTION
This change provides a default CircleCI executor with sensible defaults for Gradle tasks. After iterating on WPAndroid for some time I'm confident these values are a very good starting point for Android builds.

Individual Android projects can override these with their own `gradle.properties` or with command line arguments.

Here is a build using this change: https://circleci.com/workflow-run/2dff4232-4d16-4ff3-aae5-a2bbf2b60714