### PR TITLE
Use job name as default cache key prefix

### DIFF
--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -32,7 +32,7 @@ commands:
     parameters:
       cache-prefix:
         type: string
-        default: gradle-cache
+        default: gradle-{{ .Environment.CIRCLE_JOB }}
     steps:
       - generate-gradle-checksums
       - restore_cache:
@@ -45,7 +45,7 @@ commands:
     parameters:
       cache-prefix:
         type: string
-        default: gradle-cache
+        default: gradle-{{ .Environment.CIRCLE_JOB }}
     steps:
       - save_cache:
           paths:

--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -167,7 +167,7 @@ commands:
     parameters:
       cache-prefix:
         type: string
-        default: dependency-cache
+        default: ios-{{ .Environment.CIRCLE_JOB }}
       bundle-install:
         type: boolean
         default: true


### PR DESCRIPTION
Currently, it is necessary to provide an explicit cache prefix for every CircleCI job to avoid conflicting caches. This is a small change so that the cache prefix defaults to the job name. It is still possible to override this on a per-job basis.

You can see a WPAndroid build that uses this update [here](https://circleci.com/gh/wordpress-mobile/WordPress-Android/7669).