### PR TITLE
Android: Only download Firebase test results

### DIFF
--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -146,12 +146,10 @@ commands:
           when: always
           command: |
             mkdir ~/results
-            mkdir ~/test_results
 
             TEST_BUCKET=$(cat log.txt | grep -o "gs://test\-lab\-.*/" | head -1)
-            gsutil -m cp -r -U "$TEST_BUCKET*" ~/results/
-            find ~/results -name "*.xml" -exec cp {} ~/test_results/ \;
+            gsutil -m cp -r -U "$TEST_BUCKET**test_result*.xml" ~/results
       - store_test_results:
-          path: ~/test_results
+          path: ~/results
       - store_artifacts:
           path: ~/results


### PR DESCRIPTION
It turns out that downloading all test artifacts can be quite slow for large test runs. There is also a chance that log files could contain credentials that we may not want to reveal in CircleCI artifacts.

This is a simple change to only download the test result files (previously is would download logcat logs, videos etc.). Everything else can be accessed by going to the Firebase console.

Here is a test run using this: https://circleci.com/gh/wordpress-mobile/WordPress-FluxC-Android/618