### PR TITLE
iOS: Fix test job by passing through all parameters

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -108,7 +108,22 @@ jobs:
       xcode-version: << parameters.xcode-version >>
     steps:
       - checkout
-      - test
+      - test:
+          xcode-version: << parameters.xcode-version >>
+          workspace: << parameters.workspace >>
+          project: << parameters.project >>
+          scheme: << parameters.scheme >>
+          target: << parameters.target >>
+          configuration: << parameters.configuration >>
+          ios-version: << parameters.ios-version >>
+          device: << parameters.device >>
+          cache-prefix: << parameters.cache-prefix >>
+          bundle-install: << parameters.bundle-install >>
+          bundler-working-directory: << parameters.bundler-working-directory >>
+          pod-install: << parameters.pod-install >>
+          cocoapods-working-directory: << parameters.cocoapods-working-directory >>
+          carthage-update: << parameters.carthage-update >>
+          carthage-working-directory: << parameters.carthage-working-directory >>
   validate-podspec:
     description: |
       Run 'pod lib lint' on a provided .podspec file.


### PR DESCRIPTION
By introducing the `test` command in https://github.com/wordpress-mobile/circleci-orbs/pull/24, I inadvertently broke the existing job. This fixes the issue by simply passing through the needed params.

You can see [this build](https://circleci.com/gh/wordpress-mobile/WordPress-iOS/8112) works as expected.