### PR TITLE
iOS: Store raw xcodebuild logs and iOS Simulator crashes as artifacts

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -228,7 +228,8 @@ commands:
       - run:
           name: Build
           command: |
-            xcodebuild build-for-testing $XCODEBUILD_ARGS | xcpretty
+            mkdir -p logs
+            xcodebuild build-for-testing $XCODEBUILD_ARGS | tee logs/build.log | xcpretty
       - run:
           name: Wait for simulator
           command: |
@@ -240,9 +241,17 @@ commands:
       - run:
           name: Test
           command: |
-            xcodebuild test-without-building $XCODEBUILD_ARGS -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" | xcpretty -r junit
+            xcodebuild test-without-building $XCODEBUILD_ARGS -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" | tee logs/test.log | xcpretty -r junit
       - store_test_results:
           path: build/reports
+      - store_artifacts:
+          name: Save xcodebuild logs
+          path: logs
+          destination: logs
+      - store_artifacts:
+          name: Save crash logs
+          path: ~/Library/Logs/DiagnosticReports/
+          destination: crashes
   prepare-podspec:
     description: |
       Prepare to run CococaPods commands on a .podspec file. Runs 'bundle install' and downloads/updates the CocoaPods specs repo if needed.


### PR DESCRIPTION
While investigating https://github.com/wordpress-mobile/WordPress-iOS/issues/11848, I noticed it can be tricky to debug failing iOS tests.

This small change adds the raw `xcodebuild` logs and any crashes from the iOS Simulator as artifacts on the CircleCI job. See the artifacts tab on [this job](https://circleci.com/gh/wordpress-mobile/WordPress-iOS/8281) as an example.