### PR TITLE
Fix iOS simulator booting on Xcode 11

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -230,7 +230,7 @@ commands:
               DEVICES_KEY=$(xcrun simctl list -j | jq -r --arg DEVICES_KEY "$DEVICES_KEY" '[.runtimes[] | select (.name==$DEVICES_KEY)][0] | .identifier')
             fi
 
-            UDID=$(xcrun simctl list -j | jq -r --arg DEVICES_KEY "$DEVICES_KEY" '[.devices[$DEVICES_KEY][] | select(.name | test("<< parameters.device >>"; "i")) | select (.availability == "(available)")][0] | .udid')
+            UDID=$(xcrun simctl list -j | jq -r --arg DEVICES_KEY "$DEVICES_KEY" '[.devices[$DEVICES_KEY][] | select(.name | test("<< parameters.device >>"; "i")) | select (.isAvailable == true or .availability == "available")][0] | .udid')
 
             xcrun simctl boot $UDID # Boot simulator in the background
             echo "export SIMULATOR_UDID=$UDID" >> $BASH_ENV


### PR DESCRIPTION
The `simctl` format has changed in Xcode 11. This updates it