### PR TITLE
Add new Orb to download Github repositories as zips

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,12 @@ workflows:
           orb-ref: "wordpress-mobile/danger@dev:${CIRCLE_BRANCH}"
           requires: ["Validate Orbs"]
 
+      - orb-tools/publish:
+          name: "Git: Publish Dev"
+          orb-path: src/git/orb.yml
+          orb-ref: "wordpress-mobile/git@dev:${CIRCLE_BRANCH}"
+          requires: ["Validate Orbs"]
+
   publish:
     jobs:
       - orb-tools/publish:
@@ -62,6 +68,16 @@ workflows:
           name: "Danger: Publish"
           orb-path: src/danger/orb.yml
           orb-ref: "wordpress-mobile/danger@${CIRCLE_TAG}"
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+
+      - orb-tools/publish:
+          name: "Git: Publish"
+          orb-path: src/git/orb.yml
+          orb-ref: "wordpress-mobile/git@${CIRCLE_TAG}"
           filters:
             tags:
               only: /.*/

--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -1,0 +1,35 @@
+version: 2.1
+
+description: |
+  Some common tasks for working with git and Github
+
+commands:
+  checkout-as-zip:
+    description: Download the repository as a zip using the Github API
+    parameters:
+      use-merge:
+        description: Download the merge if this is a pull request
+        default: false
+        type: boolean
+    steps:
+      - run:
+          name: Download Github repository as zip
+          command:  |
+            REF="$CIRCLE_SHA1"
+            OUTPUT_DIRECTORY="$CIRCLE_PROJECT_REPONAME-$REF"
+
+            <<# parameters.use-merge >>
+            if [ -n "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" != "develop" ]; then
+              # Checkout merge if this is a PR
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              REF="pull/$PR_NUMBER/head"
+              OUTPUT_DIRECTORY="$CIRCLE_PROJECT_REPONAME-pull-$PR_NUMBER-head"
+            fi
+            <</ parameters.use-merge >>
+
+            cd ~
+            # Expand ~ in working directory path path
+            WD="${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}"
+            rm -rf "$WD"
+            curl -s#L "https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/archive/$REF.zip" | bsdtar -xvf-
+            mv "$OUTPUT_DIRECTORY" "$WD"


### PR DESCRIPTION
This adds a new Orb for git and Github tasks. The first is a command, `checkout-as-zip` which replaces the default `checkout` by downloading the current ref from the Github API as a zip.