### PR TITLE
Git: Update shallow clone to use same logic as default CircleCI step

### DIFF
--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -10,9 +10,57 @@ commands:
       - run:
           name: Shallow checkout
           command: |
-            git clone -b "${CIRCLE_BRANCH}" --depth 1 "${CIRCLE_REPOSITORY_URL}" .
-            git fetch --force --depth 1 origin "${CIRCLE_SHA1}"
-            git reset --hard "${CIRCLE_SHA1}"
+            set -e
+
+            # Workaround old docker images with incorrect $HOME
+            # check https://github.com/docker/docker/issues/2968 for details
+            if [ "${HOME}" = "/" ]
+            then
+              export HOME=$(getent passwd $(id -un) | cut -d: -f6)
+            fi
+
+            mkdir -p ~/.ssh
+
+            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+            ' \>> ~/.ssh/known_hosts
+
+            (umask 077; touch ~/.ssh/id_rsa)
+            chmod 0600 ~/.ssh/id_rsa
+            (cat \<<EOF > ~/.ssh/id_rsa
+            $CHECKOUT_KEY
+            EOF
+            )
+
+            # use git+ssh instead of https
+            git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
+            git config --global gc.auto 0 || true
+
+            if [ -e .git ]
+            then
+              git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
+            else
+              git clone "$CIRCLE_REPOSITORY_URL" --single-branch --branch "$CIRCLE_BRANCH" --depth 1 .
+            fi
+
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              git fetch --force origin "refs/tags/${CIRCLE_TAG}" --depth 1
+            else
+              git fetch --force origin "${CIRCLE_BRANCH}:remotes/origin/${CIRCLE_BRANCH}" --depth 1
+            fi
+
+
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q "$CIRCLE_TAG"
+            elif [ -n "$CIRCLE_BRANCH" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q -B "$CIRCLE_BRANCH"
+            fi
+
+            git reset --hard "$CIRCLE_SHA1"
 
   checkout-as-zip:
     description: Download the repository as a zip using the Github API


### PR DESCRIPTION
The new `shallow-clone` step I added yesterday has been failing in some cases. This updates it to use the same logic as the default checkout step, just changing it to be shallow.

It will now work for closed source repos.