### PR TITLE
Android: Update Gradle cache at least once a day to ensure it doesn't go stale

### DIFF
--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -27,6 +27,8 @@ commands:
             # This finds all *.gradle files (apart from the root build.gradle) and generates checksums for caching
             find . -mindepth 2 -name "*.gradle" -type f | sort | xargs shasum > gradle-checksums.txt
             cat gradle-checksums.txt
+            # Output the current date in order to prevent a very stale cache
+            date +"%Y/%m/%d" > date.txt
   restore-gradle-cache:
     description: Restore the cache of ~/.gradle based on the local build files.
     parameters:
@@ -37,6 +39,7 @@ commands:
       - generate-gradle-checksums
       - restore_cache:
           keys:
+            - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "gradle-checksums.txt" }}-{{ checksum "date.txt" }}
             - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "gradle-checksums.txt" }}
             - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-
             - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-
@@ -50,7 +53,7 @@ commands:
       - save_cache:
           paths:
             - ~/.gradle
-          key: <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "gradle-checksums.txt" }}
+          key: <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "gradle-checksums.txt" }}-{{ checksum "date.txt" }}
   save-test-results:
     description: Store the results of Gradle test tasks as artifacts and test results on CircleCI.
     steps:


### PR DESCRIPTION
The current Gradle cache key is imperfect and can remain unchanged for quite some time. This means the cache goes stale and builds slow down. This is a tiny change to append the current date to the key so it is updated at least once a day.