### PR TITLE
iOS: Handle case where Podfile.lock has no 'SPEC REPOS' entry

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -400,7 +400,7 @@ commands:
                 command: |
                   cd "<< parameters.cocoapods-working-directory >>"
 
-                  USES_MASTER_SPECS=$(ruby -e "require 'yaml';puts YAML.load_file('Podfile.lock')['SPEC REPOS'].include? 'https://github.com/cocoapods/specs.git'")
+                  USES_MASTER_SPECS=$(ruby -e "require 'yaml';repos = YAML.load_file('Podfile.lock')['SPEC REPOS'];puts (repos.nil? || repos.include?('https://github.com/cocoapods/specs.git'))")
 
                   if [ "$SKIP_POD_INSTALL" = true ]; then
                     echo "Pod install is skipped, not downloading specs."


### PR DESCRIPTION
@SergioEstevao encountered a limitation of the current implementation where it would fail if `Podfile.lock` did not contain a `SPEC REPOS` entry. This is a simple fix for that.

You can see the patch working with MediaPicker-iOS [here](https://circleci.com/gh/wordpress-mobile/MediaPicker-iOS/145).