### PR TITLE
iOS: Default to CDN specs repo when CocoaPods >= 1.8.0

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -136,7 +136,7 @@ jobs:
       sources:
         description: The --sources option to pass to 'pod lib lint'.
         type: string
-        default: master
+        default: ""
       update-specs-repo:
         description: Should the CocoaPods Specs repo be updated with 'pod repo update' before running?
         type: boolean
@@ -179,7 +179,7 @@ jobs:
       - prepare-podspec:
           podspec-path: << parameters.podspec-path >>
           bundle-install: << parameters.bundle-install >>
-          sources: master
+          sources: ""
       - run:
           name: Set Environment Variables
           command: |
@@ -214,7 +214,7 @@ commands:
       sources:
         description: The CocoaPods specs repos to use. e.g. https://github.com/artsy/Specs,master
         type: string
-        default: master
+        default: ""
     steps:
       - when:
           condition: << parameters.bundle-install >>
@@ -225,13 +225,23 @@ commands:
       - run:
           name: Fetch CocoaPods Specs (if needed)
           command: |
-            # Check if the sources parameter includes the master specs repo
-            SOURCES=$(echo "<< parameters.sources >>" | tr '[:upper:]' '[:lower:]')
-            SOURCES_ARR=${SOURCES//,/ }
-            if [[ " ${SOURCES_ARR[@]} " =~ " master " ]] || [[ " ${SOURCES_ARR[@]} " =~ " https://github.com/cocoapods/specs " ]]; then
+            # If no explicit source given, determine the default for this version of CocoaPods
+            if [ -z "<< parameters.sources >>" ]; then
+              COCOAPODS_VERSION=$(<<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod --version)
+              if [ $(ruby -e "puts '$COCOAPODS_VERSION' >= '1.8.0'") == "true" ]; then
+                echo "No source provided and CocoaPods version is >= 1.8.0, not downloading master specs repo ..."
+              else
                 curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+              fi
             else
-                echo "Doesn't use master specs repo. Skipping download ..."
+              # Source provided, check if the sources parameter includes the master specs repo
+              SOURCES=$(echo "<< parameters.sources >>" | tr '[:upper:]' '[:lower:]')
+              SOURCES_ARR=${SOURCES//,/ }
+              if [[ " ${SOURCES_ARR[@]} " =~ " master " ]] || [[ " ${SOURCES_ARR[@]} " =~ " https://github.com/cocoapods/specs " ]]; then
+                  curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+              else
+                  echo "Doesn't use master specs repo. Skipping download ..."
+              fi
             fi
   boot-simulator:
     description: |


### PR DESCRIPTION
We're coming closer to hitting our CircleCI limit each month so I'm making a few small changes to improve usage.

This adds improved support for the [CocoaPods CDN Specs repo](https://blog.cocoapods.org/CocoaPods-1.7.2/). CocoaPods 1.8.0 switched to using the CDN specs repo by default so this changes our logic to not download the master specs repo if no explicit repo is given and the version is >= 1.8.0.

You can see this in action on WordPressAuthenticator [here](https://circleci.com/gh/wordpress-mobile/WordPressAuthenticator-iOS/970). In this case it reduces the time to validate the podspec from **~12 minutes to ~3 minutes**.