### PR TITLE
Fix a case-sensitivity issue in spec URL

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -438,7 +438,7 @@ commands:
                 command: |
                   cd "<< parameters.cocoapods-working-directory >>"
 
-                  USES_MASTER_SPECS=$(ruby -e "require 'yaml';repos = YAML.load_file('Podfile.lock')['SPEC REPOS'];puts (repos.nil? || repos.include?('https://github.com/cocoapods/specs.git'))")
+                  USES_MASTER_SPECS=$(ruby -e "require 'yaml';repos = YAML.load_file('Podfile.lock')['SPEC REPOS'];puts (repos.nil? || repos.keys.map(&:downcase).include?('https://github.com/cocoapods/specs.git'))")
 
                   if [ "$SKIP_POD_INSTALL" = true ]; then
                     echo "Pod install is skipped, not downloading specs."


### PR DESCRIPTION
When checking the URL to see if it matches, properly handle potentially incorrectly cased URLs.

A failure of this can be seen in [this CI job](https://app.circleci.com/jobs/github/wordpress-mobile/WordPressAuthenticator-iOS/982).