### PR TITLE
iOS: Use more sensible defaults in preparation for a 1.0 release

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -11,7 +11,7 @@ dependency_parameters: &dependency_parameters
   bundle-install:
     description: Should 'bundle install' be run? If true, 'bundle exec' will be used for CocoaPods commands.
     type: boolean
-    default: true
+    default: false
   bundler-working-directory:
     description: The directory containing your project's Gemfile.
     type: string
@@ -19,7 +19,7 @@ dependency_parameters: &dependency_parameters
   pod-install:
     description: Should 'pod install' be run?
     type: boolean
-    default: true
+    default: false
   cocoapods-working-directory:
     description: The directory containing your project's Podfile and Podfile.lock.
     type: string
@@ -46,7 +46,7 @@ podspec_parameters: &podspec_parameters
   bundle-install:
     description: Should 'bundle install' be run? If true, 'bundle exec' will be used for CocoaPods commands.
     type: boolean
-    default: true
+    default: false
 
 device_parameters: &device_parameters
   ios-version:


### PR DESCRIPTION
The Orbs in this repo have been working really well for us and we are using them across many projects. One slightly annoying detail is that each project is using a slightly different Orb version, usually the latest when it was created.

An easy solution to this is to use flexible versioning in our CircleCI configs. i.e. Specify `wordpress-mobile/ios@1.1` instead of `wordpress-mobile/ios@1.1.2`. This would mean that when an improvement is made and released from this repo, every project starts getting the changes, provided the changes are backwards compatible.

We could start doing that right away, but I would like to make a few small improvements so that maintaining backwards compatibility is easier.

This is a very small change to make the default values in the iOS Orb more predictable. Currently `bundle install` and `pod install` is run for every project. Here I am just changing it so that it has to be specified explicitly. Its more consistent to what we do elsewhere and its easier to understand for any new projects using the Orb.