### PR TITLE
iOS: Update publish-podspec Slack message to be more succinct and include a note about CDN Specs

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -206,8 +206,11 @@ jobs:
           condition: << parameters.post-to-slack >>
           steps:
             - slack/notify:
-                message: ":tada: :ship: ${POD_NAME} ${POD_VERSION} successfully published to CocoaPods trunk!"
+                message: ":tada: ${POD_NAME} ${POD_VERSION} successfully published to CocoaPods trunk!\nIt will take a few minutes for this version to be deployed to the CocoaPods CDN."
                 webhook: ${PODS_SLACK_WEBHOOK}
+                include_project_field: false
+                include_job_number_field: false
+                include_visit_job_action: false
 
 commands:
   prepare-podspec:


### PR DESCRIPTION
This is just a small update to the format and text of the Slack message when a pod is published.

I have removed some redundant parts and added a note about the delay deploying to the CDN specs repo.

## Before

![image](https://user-images.githubusercontent.com/1773641/66489751-058c5900-eaa8-11e9-883d-82e307089cb8.png)

## After

![image](https://user-images.githubusercontent.com/1773641/66489829-22289100-eaa8-11e9-991c-44fbd095c3e6.png)

