### PR TITLE
Support flaky test attempt argument for Firebase tests

### DIFF
--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -99,6 +99,9 @@ commands:
       timeout:
         type: string
         default: 15m
+      num-flaky-test-attempts:
+        type: integer
+        default: 0
       results-history-name:
         type: string
         default: ""
@@ -140,6 +143,7 @@ commands:
             COMMAND="${COMMAND} <<# parameters.no-record-video >>--no-record-video<</ parameters.no-record-video >>"
             COMMAND="${COMMAND} $(optional_argument --results-history-name "<<parameters.results-history-name>>")"
             COMMAND="${COMMAND} $(optional_argument --test-targets "<<parameters.test-targets>>")"
+            COMMAND="${COMMAND} $(optional_argument --num-flaky-test-attempts "<<parameters.num-flaky-test-attempts>>")"
 
             echo "${COMMAND}"
             echo


### PR DESCRIPTION
Updates the Firebase functionality in the Android orb to support the [--num-flaky-test-attempts](https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run#--num-flaky-test-attempts) arguments for automatically retrying the tests in case of a failure.

You can see it working [here](https://circleci.com/gh/wordpress-mobile/WordPress-FluxC-Android/3990) - a test was broken on purpose and you can see the test results posted on Firebase show two attempts (`--num-flaky-test-attempts` was set to 1).