### PR TITLE
Retry on pod install failure after cleaning the cache

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -492,7 +492,19 @@ commands:
                           LOCKFILE_SHASUM=$(shasum Podfile.lock)
 
                           # Install pods
-                          <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install
+                          function podinstall_error () {
+                            # Untrap to avoid loops
+                            trap - ERR
+                            
+                            # Clean the repo trunk
+                            <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod repo remove trunk
+
+                            # Retry install
+                            <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install
+                          }
+                          
+                          trap podinstall_error ERR
+                          <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install  
 
                           # Check that Podfile.lock was unchanged by pod install
                           function lockfile_error () {

--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -492,19 +492,17 @@ commands:
                           LOCKFILE_SHASUM=$(shasum Podfile.lock)
 
                           # Install pods
-                          function podinstall_error () {
-                            # Untrap to avoid loops
-                            trap - ERR
-                            
+                          set +e
+                          <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install
+                          result=$?  
+                          set -e
+                          if [ $result -ne 0 ]; then
                             # Clean the repo trunk
                             <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod repo remove trunk
 
                             # Retry install
                             <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install
-                          }
-                          
-                          trap podinstall_error ERR
-                          <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install  
+                          fi
 
                           # Check that Podfile.lock was unchanged by pod install
                           function lockfile_error () {


### PR DESCRIPTION
This PR attempts to fix an issue with pods installation where new versions of a pod are not fetched from the Cocoapods CDN if an old one is in the local spec repository.
