### PR TITLE
Fix an issue cased by `jq` in catalina

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -267,7 +267,8 @@ commands:
             IOS_VERSION="<< parameters.ios-version >>"
             if [ -z "$IOS_VERSION" ]; then
               # If ios-version wasn't provided, default to the latest
-              IOS_VERSION=$(xcrun simctl list -j | jq -r '[.runtimes[] | select(.name|test("iOS."))] | sort_by(.version) | .[-1] | .version')
+              IOS_VERSION=$(ruby -e 'require "json";puts JSON.parse(`xcrun simctl list -j`)["runtimes"].select { |device| device["name"].include?("iOS") }.map { |device| device["version"] }.sort.last')
+              echo "Defaulting to latest iOS: $IOS_VERSION"
             fi
 
             # Get the UDID of the "<< parameters.device >>" with the correct iOS version


### PR DESCRIPTION
The issue details are in https://github.com/stedolan/jq/issues/1992, but this doesn’t seem like something we can fix, or even work around while still using `jq` for this particular functionality (if we can’t use the `test` operator, we can’t filter the list, AFAICT).

This change uses a really simple ruby script to parse the list and get us the same data.

**To Test:** On your local machine, run:

```
xcrun simctl list -j | jq -r '[.runtimes[] | select(.name|test("iOS."))] | sort_by(.version) | .[-1] | .version'
```

then

```
ruby -e 'require "json";puts JSON.parse(`xcrun simctl list -j`)["runtimes"].select { |device| device["name"].include?("iOS") }.map { |device| device["version"] }.sort.last'
```

Both should print the same value to the console. If they do, this PR works!


