### PR TITLE
Git: don't checkout LFS files

### DIFF
--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -35,6 +35,9 @@ commands:
             git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
             git config --global gc.auto 0 || true
 
+            # Don't download LFS stuff
+            export GIT_LFS_SKIP_SMUDGE=1
+
             if [ -e .git ]
             then
               git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true


### PR DESCRIPTION
This PR changes the `git checkout` configuration in order to avoid downloading the files from LFS. We use LFS only for resources for enhanced screenshots, so we don't need it on CI right now. 
Also, cloning and checking out may be quicker and we don't risk to exceed the LFS quota limit. 

Test PRs using this branch:
- WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/12927
- WCiOS: https://github.com/woocommerce/woocommerce-ios/pull/1458
