### PR TITLE
Fix cloning when branch is not set

### DIFF
--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -41,7 +41,7 @@ commands:
             if [ -e .git ]
             then
               git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
-            elif [[ "$CIRCLE_BRANCH" =~ pull/[0-9]+$ ]]
+            elif [[ "$CIRCLE_BRANCH" =~ pull/[0-9]+$ ]] || [ -z "$CIRCLE_BRANCH" ]
             then
               # We can't clone a single branch for forks
               git clone "$CIRCLE_REPOSITORY_URL" --depth 1 .
@@ -52,6 +52,7 @@ commands:
             if [ -n "$CIRCLE_TAG" ]
             then
               git fetch --force origin "refs/tags/${CIRCLE_TAG}" --depth 1
+              git fetch --depth 1 origin tag ${CIRCLE_TAG}
             elif [[ "$CIRCLE_BRANCH" =~ pull/[0-9]+$ ]]
             then
               # Different fetch logic is needed for forks


### PR DESCRIPTION
This PR fixes a bug with `shallow-checkout` where the checkout fails if `CIRCLE_BRANCH` is not set, which happens everytime the build is triggered by a `tag`.
This also makes sure that the label of the tag is fetched into the local repository and not only the commit. 

You can see it working in https://github.com/wordpress-mobile/WordPress-iOS/pull/13658