### PR TITLE
Add steps to zip and save test output

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -339,9 +339,13 @@ commands:
           name: Save crash logs
           path: ~/Library/Logs/DiagnosticReports/
           destination: crashes
+      - run:
+          name: Zip test output
+          working_directory: build/results
+          command: zip -r testoutput.zip *
       - store_artifacts:
-          name: Save test bundles and other output
-          path: build/results
+          name: Save test output
+          path: build/results/testoutput.zip
           destination: testresults
   test:
     description: |

--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -339,6 +339,10 @@ commands:
           name: Save crash logs
           path: ~/Library/Logs/DiagnosticReports/
           destination: crashes
+      - store_artifacts:
+          name: Save test bundles and other output
+          path: build/results
+          destination: testresults
   test:
     description: |
       Build and test an iOS project using xcodebuild


### PR DESCRIPTION
This adds steps to `save-xcodebuild-artifacts` to zip and save test output, including `.xcresult` files. (Without zipping first, the `.xcresult` is not saved correctly.)

We were already doing this in the WPiOS project, but this change:

1. Moves the steps into the orb to be reused in other projects.
2. Updates the path to match the changes to test runs in https://github.com/wordpress-mobile/WordPress-iOS/pull/13810.

You can see these changes on the `ci/circleci: Unit Tests` and `ci/circleci: UI Tests` checks on that PR; check the Artifacts tab in CircleCI to see how the test output is saved there.

Note: We will need to merge this PR before https://github.com/wordpress-mobile/WordPress-iOS/pull/13810, but we should wait until that PR is almost ready to merge to sync up with the changes to where test output is saved.