### PR TITLE
Revert "Add steps to zip and save test output"

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -339,14 +339,6 @@ commands:
           name: Save crash logs
           path: ~/Library/Logs/DiagnosticReports/
           destination: crashes
-      - run:
-          name: Zip test output
-          working_directory: build/results
-          command: zip -r testoutput.zip *
-      - store_artifacts:
-          name: Save test output
-          path: build/results/testoutput.zip
-          destination: testresults
   test:
     description: |
       Build and test an iOS project using xcodebuild


### PR DESCRIPTION
Reverts wordpress-mobile/circleci-orbs#56

These changes are causing test failures in the WooCommerce iOS repo. I'll revert and work on a better implementation for everywhere the orb is used.