### PR TITLE
Add an option to handle submodule initialization

### DIFF
--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -6,6 +6,11 @@ description: |
 commands:
   shallow-checkout:
     description: Performs a shallow clone of the repository
+    parameters:
+      init-submodules:
+        description: Inits and updates submodules
+        default: false
+        type: boolean
     steps:
       - run:
           name: Shallow checkout
@@ -73,6 +78,11 @@ commands:
             fi
 
             git reset --hard "$CIRCLE_SHA1"
+
+            <<# parameters.init-submodules >>
+            git submodule init
+            git submodule update
+            <</ parameters.init-submodules >>
 
   checkout-as-zip:
     description: Download the repository as a zip using the Github API


### PR DESCRIPTION
This PR adds an option to init and update submodules after having checked out the main repository. 
This is required for some libraries that are imported as submodules into the client project. 

You can see this is action here: https://github.com/wordpress-mobile/WordPress-Android/pull/11877.