### PR TITLE
Fix checkout failures

### DIFF
--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -77,7 +77,11 @@ commands:
               git checkout -q -B "$CIRCLE_BRANCH"
             fi
 
-            git reset --hard "$CIRCLE_SHA1"
+            if git cat-file -e "$CIRCLE_SHA1"; then
+              git reset --hard "$CIRCLE_SHA1"
+            else
+              circleci-agent step halt
+            fi
 
             <<# parameters.init-submodules >>
             git submodule init


### PR DESCRIPTION
This fixes checkout issues by:

1) Checking if the ref exists before attempting to use `git reset`
2) If the ref does not exist, it exits the job