### PR TITLE
Allow firebase-test command to use a device matrix

### DIFF
--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -93,7 +93,28 @@ commands:
       test-apk-path:
         type: string
       device:
+        description: |
+          Single device specifier (e.g. `model=blueline,version=28,orientation=portrait,locale=en_US`), to run the tests on a single device.
+          Ignored when you provide a value for `devices`. Obsolete, prefer using `devices` for 
+          Can be combined with `locales` to build a matrix of device specifiers for a single device but multiple locales.
+        default: ""
         type: string
+      devices:
+        description: |
+          Space-or-newline-separated list of device specifiers, to run the tests on a multiple devices. Takes precedence over the `device` parameter.
+          e.g. `model=blueline,version=28,orientation=portrait,locale=en_US model=blueline,version=29,orientation=landscape,locale=ar`.
+
+          When a `locales` parameter is also provided, this specifiers in this list are supposed to *not* contain the locale dimension, and the command
+          will build a matrix of the `devices` list and the `locales` list to generate tests on all possible combination of both dimensions.
+        default: ""
+        type: string
+      locales:
+        description: |
+          Space-or-newline-separated list of locale codes to combine with the list of `devices`. e.g. `ar en_US fr_FR`.
+          When provided, the command will build a matrix of the `devices` list and the `locales` list to generate tests on all possible combination
+          of both dimensions, by appending the `,locale=…` dimension to each device specifier provided in the `devices` list for each locale.
+        type: string
+        default: ""
       project:
         type: string
       timeout:
@@ -131,12 +152,33 @@ commands:
               fi
             }
 
+            device_arguments() {
+              DEVICE="<<parameters.device>>"
+              DEVICES="<<parameters.devices>>"
+              LOCALES="<<parameters.locales>>"
+
+              if [ -z "$DEVICES" ]; then
+                DEVICES=$DEVICE
+              fi
+              if [ -z "$LOCALES" ]; then
+                for device in $DEVICES; do
+                  echo -n "--device \"$device\" "
+                done
+              else
+                for device in $DEVICES; do
+                  for locale in $LOCALES; do
+                    echo -n "--device \"$device,locale=$locale\" "
+                  done
+                done
+              fi
+            }
+
             COMMAND="gcloud firebase test android run"
             COMMAND="${COMMAND} --type \"<<parameters.type>>\""
             COMMAND="${COMMAND} --app \"<<parameters.apk-path>>\""
             COMMAND="${COMMAND} --test \"<<parameters.test-apk-path>>\""
             COMMAND="${COMMAND} --timeout \"<<parameters.timeout>>\""
-            COMMAND="${COMMAND} --device \"<<parameters.device>>\""
+            COMMAND="${COMMAND} $(device_arguments)"
             COMMAND="${COMMAND} --project \"<<parameters.project>>\""
             COMMAND="${COMMAND} --verbosity info"
             COMMAND="${COMMAND} <<parameters.additional-parameters>>"

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -144,7 +144,7 @@ commands:
           command: gcloud auth activate-service-account --key-file "<<parameters.key-file>>"
       - run:
           name: Run tests on Firebase Test Lab
-          no_output_timeout: 3h # Set to a large value as firebase manages its own timeout.
+          no_output_timeout: 1h # Set to a large value as firebase manages its own timeout.
           command: |
             optional_argument () {
               OPTION="$1"

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -144,7 +144,7 @@ commands:
           command: gcloud auth activate-service-account --key-file "<<parameters.key-file>>"
       - run:
           name: Run tests on Firebase Test Lab
-          no_output_timeout: 1h # Set to a large value as firebase manages its own timeout.
+          no_output_timeout: 3h # Set to a large value as firebase manages its own timeout.
           command: |
             optional_argument () {
               OPTION="$1"

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -95,7 +95,8 @@ commands:
       device:
         description: |
           Single device specifier (e.g. `model=blueline,version=28,orientation=portrait,locale=en_US`), to run the tests on a single device.
-          Ignored when you provide a value for `devices`. Obsolete, prefer using `devices` for 
+          Ignored when you provide a value for `devices`. Obsolete, prefer using `devices` instead.
+ 
           Can be combined with `locales` to build a matrix of device specifiers for a single device but multiple locales.
         default: ""
         type: string
@@ -104,14 +105,15 @@ commands:
           Space-or-newline-separated list of device specifiers, to run the tests on a multiple devices. Takes precedence over the `device` parameter.
           e.g. `model=blueline,version=28,orientation=portrait,locale=en_US model=blueline,version=29,orientation=landscape,locale=ar`.
 
-          When a `locales` parameter is also provided, this specifiers in this list are supposed to *not* contain the locale dimension, and the command
-          will build a matrix of the `devices` list and the `locales` list to generate tests on all possible combination of both dimensions.
+          When a `locales` parameter is also provided, the specifiers in this list are supposed to *not* contain the locale dimension, and the command
+          will build a matrix of the `devices` list and the `locales` list to generate tests on all possible combinations of both lists.
         default: ""
         type: string
       locales:
         description: |
           Space-or-newline-separated list of locale codes to combine with the list of `devices`. e.g. `ar en_US fr_FR`.
-          When provided, the command will build a matrix of the `devices` list and the `locales` list to generate tests on all possible combination
+
+          When provided, the command will build a matrix of the `devices` list and the `locales` list to generate tests on all possible combinations
           of both dimensions, by appending the `,locale=…` dimension to each device specifier provided in the `devices` list for each locale.
         type: string
         default: ""


### PR DESCRIPTION
This change allows the `android/firebase-test` command to take a list of devices, instead of limiting it to only one device.

## Why?

This is required in order to trigger a Firebase Test Lab run in a single matrix on multiple devices at once.
This is especially needed in order to build the PlayStore promo screenshots for WPAndroid (PR coming soon)

## What changed?

### New command parameters

The command now allows 2 new parameters:
 - `devices` (plural): a space-or-newline-separated list of device specifiers
 - `locales`: a space-or-newline-separated list of locale codes

Note that the old `device` (singular) parameter has been kept for backward-compatibility reasons. Because of this, we couldn't mark the `devices` parameter as required (we had to provide a `default: ""` value).

 - The new `devices` parameter takes precedence over the old `device` parameter
 - When you provide a value for the `device` parameter but don't provide one for `devices`, it acts like if you provided that value on the `devices` parameter instead

We can imagine removing that `device` parameter in a future 2.x.x major version bump of the orb, but I think for now it's ok to keep it for easier transitioning.

### Parameters interpretation to build the Matrix

 - When you only provide the `device` or `devices` parameter but no `locales` parameter, the list of devices passed to that `devices` parameter is used as-is to generate a list of `--device` arguments for the `gcloud` command
    - In that case, each device listed in the `devices` parameter is expected to have all its necessary dimensions (`model`, `version`, `orientation`, `locale`) specified
 - When you provide a list of values for the `locales` parameter, the command will build a matrix of all possible combinations of the provided device specifiers and the provided locales.
    - e.g. if you provide 2 devices and 6 locales, it will build a list of the 12 possible combinations to pass as 12 `--device` arguments to the `gcloud` command.
    - In that case, each device listed in the `devices` parameter is expected to _not_ have the `locale` dimension specified, since that dimension will be added when combining the partial device specifier with the list of `locales`.


## Testing

This orb command has already been tested as part of [the pending `feature/screenshots-phase1` branch on WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/compare/feature/build-screenshots-on-ci...AliSoftware:feature/screenshots-phase1#files_bucket) – for which a PR is coming soon too.

During the work on that branch, I used the code seen in that orb's PR as  local `localcmd-firebase-test` command defined directly in WPAndroid's `.circleci/config.yml` (instead of pointing to the orb's `android/firebase-test` command), and was able to validate that its code works as expected for 2 devices and 2 locales.  
Once the local command was validated, I just copy/pasted the code of that local command back into the orb here.

## Next Steps

Once this PR is reviewed and hopefully merged, we'll need to publish a new release of it to the orb registry, so that WPAndroid's `.circleci/config.yml` can point to it and use that new version.


![](https://media2.giphy.com/media/zXmbOaTpbY6mA/giphy.gif)
