### PR TITLE
Add select simulator command

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -265,17 +265,18 @@ commands:
                   echo "Doesn't use master specs repo. Skipping download ..."
               fi
             fi
-  boot-simulator:
+  select-simulator:
     description: |
-      Boot an iOS simulator in the background.
+      Select the iOS simulator that matches the given parameters and export as environment variables its name, ios version, and UDID.
     parameters:
       <<: *xcode_version_parameter
       <<: *device_parameters
     steps:
       - run:
-          name: Boot simulator
+          name: Select simulator
           command: |
             IOS_VERSION="<< parameters.ios-version >>"
+            DEVICE_NAME="<< parameters.device >>"
             if [ -z "$IOS_VERSION" ]; then
               # If ios-version wasn't provided, default to the latest
               IOS_VERSION=$(ruby -e 'require "json";puts JSON.parse(`xcrun simctl list -j`)["runtimes"].select { |device| device["name"].include?("iOS") }.map { |device| device["version"] }.sort.last')
@@ -291,10 +292,25 @@ commands:
               DEVICES_KEY=$(xcrun simctl list -j | jq -r --arg DEVICES_KEY "$IOS_VERSION" '[.runtimes[] | select (.version==$DEVICES_KEY)][0] | .identifier')
             fi
 
-            UDID=$(ruby -e 'DEVICE_KEY=ARGV[0];DEVICE_NAME=ARGV[1].gsub("\\", "");require "json";puts JSON.parse(`xcrun simctl list -j`)["devices"][DEVICE_KEY].select { |device| device["name"] == DEVICE_NAME && (device["isAvailable"] == true || device["availability"] == "available") }.first["udid"]' $DEVICES_KEY "<< parameters.device >>")
+            DEVICE_NAME=$(ruby -e 'NAME=ARGV[0].gsub("\\", "");puts NAME' "$DEVICE_NAME")
+            UDID=$(ruby -e 'DEVICE_KEY=ARGV[0];DEVICE_NAME=ARGV[1];require "json";puts JSON.parse(`xcrun simctl list -j`)["devices"][DEVICE_KEY].select { |device| device["name"] == DEVICE_NAME && (device["isAvailable"] == true || device["availability"] == "available") }.first["udid"]' "$DEVICES_KEY" "$DEVICE_NAME")
 
-            xcrun simctl boot $UDID # Boot simulator in the background
-            echo "export SIMULATOR_UDID=$UDID" >> $BASH_ENV
+            echo "Selected simulator: $DEVICE_NAME, $IOS_VERSION, $UDID"
+            echo "export SIMULATOR_NAME='$DEVICE_NAME' SIMULATOR_IOS_VERSION='$IOS_VERSION' SIMULATOR_UDID='$UDID'" >> $BASH_ENV
+  boot-simulator:
+    description: |
+      Boot an iOS simulator in the background.
+    parameters:
+      <<: *xcode_version_parameter
+      <<: *device_parameters
+    steps:
+      - select-simulator:
+          xcode-version: << parameters.xcode-version >>
+          ios-version: << parameters.ios-version >>
+          device: << parameters.device >>
+      - run:
+          name: Boot simulator
+          command: xcrun simctl boot $SIMULATOR_UDID
           background: true
   wait-for-simulator:
     description: |


### PR DESCRIPTION
## Why

To update CircleCI to use iOS 14 for running tests (https://github.com/wordpress-mobile/WordPress-iOS/pull/15230), we need a way to determine which simulator will be used, without having to run `boot-simulator` (otherwise the "Build Tests" job would boot a simulator, which is not required).
Also, we need the name and iOS version of the selected simulator, but `boot-simulator` only provides the simulator UDID.

## How

This change extracts simulator selection logic out of the `boot-simulator` command into a separate new command, `select-simulator`. It exports the simulator name and iOS version as environment variables.

## Details

`select-simulator` selects an available simulator (via `xcrun simctl list`) which matches the characteristics specified by its input parameters `xcode-version`, `ios-version`, and `device`.
- `xcode-version` (required): The Xcode version the simulator will be used on, e.g. "10.2.0"
- `ios-version` (optional): The iOS version (e.g. "14.0") of the desired simulator
- `device` (required): The name of the given simulator, e.g. "iPhone 11" or "iPad Air (4th generation)"

It then exports three environment variables which describe the selected simulator, namely:
- `SIMULATOR_NAME`: The simulator name, e.g. "iPhone 11" or "iPad Air (4th generation)" (this is equal to the `device` input parameter)
- `SIMULATOR_IOS_VERSION`: The simulator iOS version, e.g. "14.0" - if the `ios-version` input parameter was supplied, this is equivalent, otherwise it's the latest available iOS version found by `xcrun simctl list`
- `SIMULATOR_UDID`: The UDID of the simulator matching the given name and iOS version