### PR TITLE
Remove specs cache restoration

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -489,64 +489,47 @@ commands:
                   else
                     echo "Podfile.lock does not match Pods/Manifest.lock. Pods will be installed ..."
                   fi
-            - with-cocoapods-specs-cache:
-                cache-prefix: << parameters.cache-prefix >>
-                cached-steps:
-                  - run:
-                      name: Fetch CocoaPods Specs (if needed)
-                      command: |
-                        cd "<< parameters.cocoapods-working-directory >>"
+            - run:
+                name: Pod Install (if needed)
+                command: |
+                  cd "<< parameters.cocoapods-working-directory >>"
 
-                        USES_MASTER_SPECS=$(ruby -e "require 'yaml';repos = YAML.load_file('Podfile.lock')['SPEC REPOS'];puts (repos.nil? || repos.keys.map(&:downcase).include?('https://github.com/cocoapods/specs.git'))")
+                  if [ "$SKIP_POD_INSTALL" = true ]; then
+                    echo "Skipping pod install ..."
+                  else
+                    # Get the shasum of Podfile.lock before installing pods
+                    LOCKFILE_SHASUM=$(shasum Podfile.lock)
 
-                        if [ "$SKIP_POD_INSTALL" = true ]; then
-                          echo "Pod install is skipped, not downloading specs."
-                        elif [ "$USES_MASTER_SPECS" = false ]; then
-                          echo "Podfile.lock does not use the master specs repo, skipping download."
-                        else
-                          curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
-                        fi
-                  - run:
-                      name: Pod Install (if needed)
-                      command: |
-                        cd "<< parameters.cocoapods-working-directory >>"
+                    # Install pods
+                    set +e
+                    <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install
+                    result=$?  
+                    set -e
+                    if [ $result -ne 0 ]; then
+                      # Clean the repo trunk
+                      <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod repo remove trunk
 
-                        if [ "$SKIP_POD_INSTALL" = true ]; then
-                          echo "Skipping pod install ..."
-                        else
-                          # Get the shasum of Podfile.lock before installing pods
-                          LOCKFILE_SHASUM=$(shasum Podfile.lock)
+                      # Retry install
+                      <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install
+                    fi
 
-                          # Install pods
-                          set +e
-                          <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install
-                          result=$?  
-                          set -e
-                          if [ $result -ne 0 ]; then
-                            # Clean the repo trunk
-                            <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod repo remove trunk
+                    # Check that Podfile.lock was unchanged by pod install
+                    function lockfile_error () {
+                      echo "Podfile.lock was changed by 'pod install'. Please run 'pod install' and try again."
+                    }
+                    trap lockfile_error ERR
 
-                            # Retry install
-                            <<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod install
-                          fi
-
-                          # Check that Podfile.lock was unchanged by pod install
-                          function lockfile_error () {
-                            echo "Podfile.lock was changed by 'pod install'. Please run 'pod install' and try again."
-                          }
-                          trap lockfile_error ERR
-
-                          echo
-                          echo "Checking that Podfile.lock was not modified by 'pod install'"
-                          echo "${LOCKFILE_SHASUM}" | shasum -c > /dev/null
-                        fi
-                      environment:
-                        COCOAPODS_DISABLE_STATS: true
-                  - save_cache:
-                      name: Save CocoaPods cache
-                      key: << parameters.cache-prefix >>-pods-{{ arch }}-{{ checksum "<< parameters.cocoapods-working-directory >>/Podfile.lock" }}
-                      paths:
-                        - << parameters.cocoapods-working-directory >>/Pods/
+                    echo
+                    echo "Checking that Podfile.lock was not modified by 'pod install'"
+                    echo "${LOCKFILE_SHASUM}" | shasum -c > /dev/null
+                  fi
+                environment:
+                  COCOAPODS_DISABLE_STATS: true
+            - save_cache:
+                name: Save CocoaPods cache
+                key: << parameters.cache-prefix >>-pods-{{ arch }}-{{ checksum "<< parameters.cocoapods-working-directory >>/Podfile.lock" }}
+                paths:
+                  - << parameters.cocoapods-working-directory >>/Pods/
       - when:
           condition: << parameters.carthage-update >>
           steps:


### PR DESCRIPTION
This PR removes specs cache restoration.

We don't need to restore the specs cache because there's no reason to _have_ a specs cache anymore – all of our repos rely on the CDN now [*], so this step won't hurt us performance-wise. 

In fact, in some cases it can actually hurt us if the restored Pod cache is an older version – on WPiOS we keep hitting issues where the wrong specs cache is restored, causing endless `RNCMaskedView` issues. This change _should_ help resolve those.

[*] Project Podfiles:
https://github.com/woocommerce/woocommerce-ios/blob/c90b9829f471929143ebed1b757170248566cfd2/Podfile#L1
https://github.com/wordpress-mobile/WordPress-iOS/blob/5d6cbc0870ffaa1c068bc76ea02fa4d63b12156f/Podfile#L1
https://github.com/Automattic/simplenote-ios/pull/1017
https://github.com/Automattic/simplenote-macos/pull/715/

You can see this change working [with this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/15292) – it no longer has the specs cache steps in CI, and still builds just fine.