### PR TITLE
Fix the check about the need to download the CocoaPods master repo

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -250,7 +250,7 @@ commands:
             # If no explicit source given, determine the default for this version of CocoaPods
             if [ -z "<< parameters.sources >>" ]; then
               COCOAPODS_VERSION=$(<<# parameters.bundle-install >>bundle exec<</ parameters.bundle-install >> pod --version)
-              if [ $(ruby -e "puts '$COCOAPODS_VERSION' >= '1.8.0'") == "true" ]; then
+              if ruby -e "exit Gem::Version.new('$COCOAPODS_VERSION') >= Gem::Version.new('1.8.0')"; then
                 echo "No source provided and CocoaPods version is >= 1.8.0, not downloading master specs repo ..."
               else
                 curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf


### PR DESCRIPTION
The fix was previously based on string comparison, which means it considered `"1.10.0"` to be less than `"1.8.0"` (alphabetical comparison).
Migrated the check to use `Gem::Version` to compare the versions instead.

Noticed the issue in [this WordPressAuthenticator's CircleCI build](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPressAuthenticator-iOS/2462/workflows/c0a1f0d5-0e22-4c8b-9998-c1060e0baf51/jobs/4589) which did end up downloading the master spec repo (while it was not needed because we now use CocoaPods 1.10.x), taking significantly more time than needed to release the pod because of that download step.

## Local test of the logic

Tested the old vs new conditional logic locally, using those steps in a bash shell in my Terminal:
```bash
$ bash

bash-3.2$ COCOAPODS_VERSION=1.7.3
bash-3.2$ if [ $(ruby -e "puts '$COCOAPODS_VERSION' >= '1.8.0'") == "true" ]; then echo No download needed; else echo Will download master repo; fi
Will download master repo
bash-3.2$ if ruby -e "exit Gem::Version.new('$COCOAPODS_VERSION') >= Gem::Version.new('1.8.0')"; then echo No download needed; else echo Will download master repo; fi
Will download master repo
bash-3.2$ COCOAPODS_VERSION=1.10.1
bash-3.2$ if [ $(ruby -e "puts '$COCOAPODS_VERSION' >= '1.8.0'") == "true" ]; then echo No download needed; else echo Will download master repo; fi
Will download master repo
bash-3.2$ if ruby -e "exit Gem::Version.new('$COCOAPODS_VERSION') >= Gem::Version.new('1.8.0')"; then echo No download needed; else echo Will download master repo; fi
No download needed
```