### PR TITLE
Fix CI errors when PRs are merged simultaneously

### DIFF
--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -69,11 +69,17 @@ commands:
 
             if [ -n "$CIRCLE_TAG" ]
             then
+              # The SHA1 for a given tag shouldn't change, so we *should* fail if this command doesn't work
               git reset --hard "$CIRCLE_SHA1"
               git checkout -q "$CIRCLE_TAG"
             elif [ -n "$CIRCLE_BRANCH" ]
             then
-              git reset --hard "$CIRCLE_SHA1"
+              # Don't fail the job if the hash isn't the latest
+              if git cat-file -e "$CIRCLE_SHA1"; then
+                git reset --hard "$CIRCLE_SHA1"
+              else
+                circleci-agent step halt
+              fi
               git checkout -q -B "$CIRCLE_BRANCH"
             fi
 


### PR DESCRIPTION
This should fix the issue that we keep seeing in CI when multiple PRs are merged very close together – because the CI system does a very shallow commit, the hash doesn't exist in the repo so it records a CI failure, which is incorrect.

Instead, we'll halt the job, because if the commit hash isn't the newest, CircleCI will cancel the job very shortly anyway.