### PR TITLE
Fix public key permissions

### DIFF
--- a/src/ios/orb.yml
+++ b/src/ios/orb.yml
@@ -233,6 +233,8 @@ jobs:
                   else
                     mkdir -p ~/.ssh
 
+                    (umask 077; touch ~/.ssh/pod_repo_push_deploy_key.pub)
+                    chmod 0600 ~/.ssh/pod_repo_push_deploy_key.pub
                     (cat \<<EOF > ~/.ssh/pod_repo_push_deploy_key.pub
                     $SPEC_REPO_PUBLIC_DEPLOY_KEY
                   EOF


### PR DESCRIPTION
This PR sets the correct permissions (`chmod 0600`) for the public key file we create, so that it can be used as `IdentityFile` of the ssh process.

At first I thought that only the private key had to have those restricted permissions, but it seems that even if that's a public key that we pass in our case (in order to select the right identity from the `ssh-agent`, which is where CircleCI registers the private key via the `add_ssh_keys` step), `IdentityFile` still requires permissions of `600` (not accessible by others), as can be seen in [this CI job example](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPressKit-iOS/1384/workflows/8e3c5601-8c2d-4aee-ae15-dbd798b61aa8/jobs/2543)

I'm not sure why it seems to pass sometimes (like in my previous tests, or like in [here](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPressAuthenticator-iOS/2496/workflows/e2225a87-6753-4d53-945a-765e15afd257/jobs/4665))… but not always (like above). Maybe a different version of SSH depending on the CircleCI image used? Anyway, better safe than sorry.