### PR TITLE
Adds should-publish-library-artifacts command

### DIFF
--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -218,4 +218,26 @@ commands:
             [[ -n "$CIRCLE_BRANCH" ]] && PARAMS+=(--branch-name=$CIRCLE_BRANCH)
             [[ -n "$CIRCLE_PULL_REQUEST" ]] && PARAMS+=(--pull-request-url=$CIRCLE_PULL_REQUEST)
             ./gradlew --stacktrace :<<parameters.module_name>>:publishToS3 "${PARAMS[@]}"
+  should-publish-library-artifacts:
+    description: Check if library artifacts should be published
+    steps:
+      - run:
+          name: Check if library artifacts should be published
+          command: |
+            if [[ -z "$CIRCLE_SHA1" ]]; then
+                echo "Commit hash should always be available. Since we rely on this assumption in later commands, this acts as a sanity check"
+                exit 1
+            fi
+
+            if [[ -n "$CIRCLE_TAG" ]]; then
+                echo "Proceed because we are building a tag..."
+            elif [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+                echo "Proceed because we are building a PR..."
+            elif [[ "$CIRCLE_BRANCH" == "develop" || "$CIRCLE_BRANCH" == "trunk" ]]; then
+                echo "Proceed because we are building $CIRCLE_BRANCH..."
+            else
+                echo "We only publish artifacts if the build is from a tag, a PR or from develop and trunk branches."
+                echo "Skipping publishing artifacts!"
+                circleci-agent step halt
+            fi
 

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -218,7 +218,7 @@ commands:
             [[ -n "$CIRCLE_BRANCH" ]] && PARAMS+=(--branch-name=$CIRCLE_BRANCH)
             [[ -n "$CIRCLE_PULL_REQUEST" ]] && PARAMS+=(--pull-request-url=$CIRCLE_PULL_REQUEST)
             ./gradlew --stacktrace :<<parameters.module_name>>:publishToS3 "${PARAMS[@]}"
-  should-publish-library-artifacts:
+  check-precondition-for-publish-artifacts:
     description: Check if library artifacts should be published
     steps:
       - run:
@@ -246,6 +246,7 @@ commands:
                 echo "Skipping publishing artifacts!"
                 echo ""
                 echo "If this build was triggered from a commit that is part of an open PR, it's possible it started before the PR was opened."
-                echo "In that case, simply restart the workflow an CircleCI will notice the PR and not halt here."
+                echo "In that case, simply restart the workflow and CircleCI will notice the PR and not halt here."
                 circleci-agent step halt
             fi
+

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -244,6 +244,9 @@ commands:
             else
                 echo "We only publish artifacts if the build is from a tag, a PR or from develop and trunk branches."
                 echo "Skipping publishing artifacts!"
+                echo ""
+                echo "If this build was triggered from a commit that is part of an open PR, it's possible it started before the PR was opened."
+                echo "In that case, simply restart the workflow an CircleCI will notice the PR and not halt here."
                 circleci-agent step halt
             fi
 

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -224,6 +224,12 @@ commands:
       - run:
           name: Check if library artifacts should be published
           command: |
+            echo "Environment:"
+            echo "> SHA1: $CIRCLE_SHA1"
+            echo "> tag?: $CIRCLE_TAG"
+            echo "> branch?: $CIRCLE_BRANCH"
+            echo "> PR?: $CIRCLE_PULL_REQUEST"
+
             if [[ -z "$CIRCLE_SHA1" ]]; then
                 echo "Commit hash should always be available. Since we rely on this assumption in later commands, this acts as a sanity check"
                 exit 1

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -225,7 +225,7 @@ commands:
           name: Check if library artifacts should be published
           command: |
             if [[ -z "$CIRCLE_SHA1" ]]; then
-                echo "Commit hash should always be available. Since we rely on this assumption in later commands, this acts as a sanity check"
+                echo "Commit hash should always be available. Since we rely on this assumption in later commands, this acts as a precondition check"
                 exit 1
             fi
 
@@ -240,4 +240,3 @@ commands:
                 echo "Skipping publishing artifacts!"
                 circleci-agent step halt
             fi
-


### PR DESCRIPTION
This PR adds `should-publish-library-artifacts` which checks the tag, branch name, sha1 and the pull request url to see if we'd want to publish the artifacts to S3. It's a companion to `publish-to-s3` command from https://github.com/wordpress-mobile/circleci-orbs/pull/72 and can be used before the code is checked out. The current behavior is, we'll continue to build if:
* It's from a tag
* It's from a PR
* It's from develop or trunk
* Fails if sha1 is missing
* Otherwise uses `circleci-agent step halt` to gracefully stop the build

**Note that this PR is targeting the `publish-to-s3` branch since it has commits from that PR. We can either merge #72 first and update the base branch to `develop` or merge this PR to #72 and merge them together to `develop`.**

Below script can be used to test various scenarios:

```sh
#!/bin/bash

CIRCLE_SHA1="sha1"

CIRCLE_TAG="tag"
CIRCLE_BRANCH="develop"
CIRCLE_PULL_REQUEST="pr"

if [[ -z "$CIRCLE_SHA1" ]]; then
    echo "Commit hash should always be available. Since we rely on this assumption in later commands, this acts as a sanity check"
    exit 1
fi

if [[ -n "$CIRCLE_TAG" ]]; then
    echo "Proceed because we are building a tag..."
elif [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
    echo "Proceed because we are building a PR..."
elif [[ "$CIRCLE_BRANCH" == "develop" || "$CIRCLE_BRANCH" == "trunk" ]]; then
    echo "Proceed because we are building $CIRCLE_BRANCH..."
else
    echo "We only publish artifacts if the build is from a tag, a PR or from develop and trunk branches."
    echo "Skipping publishing artifacts!"
    # circleci-agent step halt
fi
```