### PR TITLE
Add tip to halt message in should-publish-library-artifacts

### DIFF
--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -244,6 +244,9 @@ commands:
             else
                 echo "We only publish artifacts if the build is from a tag, a PR or from develop and trunk branches."
                 echo "Skipping publishing artifacts!"
+                echo ""
+                echo "If this build was triggered from a commit that is part of an open PR, it's possible it started before the PR was opened."
+                echo "In that case, simply restart the workflow an CircleCI will notice the PR and not halt here."
                 circleci-agent step halt
             fi
 

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -224,6 +224,12 @@ commands:
       - run:
           name: Check if library artifacts should be published
           command: |
+            echo "Environment:"
+            echo "> SHA1: $CIRCLE_SHA1"
+            echo "> tag?: $CIRCLE_TAG"
+            echo "> branch?: $CIRCLE_BRANCH"
+            echo "> PR?: $CIRCLE_PULL_REQUEST"
+
             if [[ -z "$CIRCLE_SHA1" ]]; then
                 echo "Commit hash should always be available. Since we rely on this assumption in later commands, this acts as a sanity check"
                 exit 1


### PR DESCRIPTION
It can happen that a developer pushes a branch for a finished feature and then opens a PR for it.

In such case, depending on the load on the CircleCI queue, the build might start before the PR is open, which would result in the S3 publishing halting, as intended.

There's not much we can do from a tooling perspective, short of building and upload every source code check in, to work around this issue.

This PR adds what is hopefully going to be useful information for developers confused by this behavior.