### PR TITLE
Refactor publish to s3 to accept gradle task param

### DIFF
--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -204,20 +204,20 @@ commands:
           path: ~/results
       - store_artifacts:
           path: ~/results
-  publish-to-s3:
+  publish-library-to-s3:
     description: Publish library artifacts to S3
     parameters:
       module_name:
         type: string
     steps:
       - run:
-          name: Publish to S3
+          name: Publish Library to S3
           command: |
             PARAMS=(--sha1=$CIRCLE_SHA1)
             [[ -n "$CIRCLE_TAG" ]] && PARAMS+=(--tag-name=$CIRCLE_TAG)
             [[ -n "$CIRCLE_BRANCH" ]] && PARAMS+=(--branch-name=$CIRCLE_BRANCH)
             [[ -n "$CIRCLE_PULL_REQUEST" ]] && PARAMS+=(--pull-request-url=$CIRCLE_PULL_REQUEST)
-            ./gradlew --stacktrace :<<parameters.module_name>>:publishToS3 "${PARAMS[@]}"
+            ./gradlew --stacktrace :<<parameters.module_name>>:publishLibraryToS3 "${PARAMS[@]}"
   check-precondition-for-publish-artifacts:
     description: Check if library artifacts should be published
     steps:

--- a/src/android/orb.yml
+++ b/src/android/orb.yml
@@ -204,20 +204,20 @@ commands:
           path: ~/results
       - store_artifacts:
           path: ~/results
-  publish-library-to-s3:
-    description: Publish library artifacts to S3
+  publish-to-s3:
+    description: Publish artifacts to S3
     parameters:
-      module_name:
+      publish_gradle_task:
         type: string
     steps:
       - run:
-          name: Publish Library to S3
+          name: Publish artifacts to S3
           command: |
             PARAMS=(--sha1=$CIRCLE_SHA1)
             [[ -n "$CIRCLE_TAG" ]] && PARAMS+=(--tag-name=$CIRCLE_TAG)
             [[ -n "$CIRCLE_BRANCH" ]] && PARAMS+=(--branch-name=$CIRCLE_BRANCH)
             [[ -n "$CIRCLE_PULL_REQUEST" ]] && PARAMS+=(--pull-request-url=$CIRCLE_PULL_REQUEST)
-            ./gradlew --stacktrace :<<parameters.module_name>>:publishLibraryToS3 "${PARAMS[@]}"
+            ./gradlew --stacktrace <<parameters.publish_gradle_task>> "${PARAMS[@]}"
   check-precondition-for-publish-artifacts:
     description: Check if library artifacts should be published
     steps:


### PR DESCRIPTION
This PR makes `publish-to-s3` more generic by converting gradle task into a parameter. This will allow us to call `publishLibraryToS3` & `publishPluginToS3` Gradle task from different projects.